### PR TITLE
Load red-dot sprite from external file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ Projeto modularizado para continuar o MVP no navegador.
 
 ## Estrutura
 - `index.html` — carrega Phaser (global) e `src/main.js` (ES modules).
+  - `src/assets/` — sprites e outros assets (ex.: `red-dot.png`).
 - `src/config.js` — constantes (tamanho, velocidades, física).
 - `src/main.js` — configura e inicia o jogo.
-- `src/scenes/BootScene.js` — preloading e geração de texturas dos personagens.
+- `src/scenes/BootScene.js` — preloading e geração de texturas/sprites dos personagens.
 - `src/scenes/GameScene.js` — mapa, câmera, colisões, HUD.
 - `src/objects/Player.js` — personagem com movimento polido (coyote time, double jump, squash).
 - `src/objects/Enemy.js` — inimigo simples com patrulha.

--- a/src/scenes/BootScene.js
+++ b/src/scenes/BootScene.js
@@ -1,5 +1,7 @@
 // src/scenes/BootScene.js
 // Usa o Phaser global (window.Phaser)
+
+
 export default class BootScene extends Phaser.Scene {
   constructor() { super('Boot'); }
 
@@ -33,8 +35,9 @@ export default class BootScene extends Phaser.Scene {
     g.fillStyle(0xcde1ff,0.8); g.fillRoundedRect(0,0,36,16,4);
     g.generateTexture('hitbox', 36, 16);
 
-    // gera sprites das formigas (emo + padrão)
-    this.createAntTexture('ant1', 0x9fd2ff, true);
+    // carrega sprite externa para o "red-dot" e mantém fallback procedural para o segundo jogador
+    const redDotURL = new URL('../assets/red-dot.png', import.meta.url);
+    this.load.image('red-dot', redDotURL.href);
     this.createAntTexture('ant2', 0xffc38f, false);
   }
 

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -48,7 +48,7 @@ export default class GameScene extends Phaser.Scene {
 
     // players
     this.players = this.add.group();
-    const p1 = new Player(this, 120, 200, 'ant1', { left:'A', right:'D', up:'W', attack:'F' });
+    const p1 = new Player(this, 120, 200, 'red-dot', { left:'A', right:'D', up:'W', attack:'F' });
     const p2 = new Player(this, 160, 200, 'ant2', { left:'LEFT', right:'RIGHT', up:'UP', attack:'SLASH' });
     this.players.addMultiple([p1,p2]); p1.postCreate(); p2.postCreate();
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,5 @@
 // vite.config.js
 export default {
   server: { open: true },
-  build: { outDir: 'dist' }
-};
+  build: { outDir: 'dist', assetsInlineLimit: 0 }
+}; 


### PR DESCRIPTION
## Summary
- load red-dot sprite from external PNG instead of Base64
- copy sprite during build by disabling asset inlining
- document new asset location in README
- remove binary sprite from repository; asset will be supplied separately

## Testing
- `npm test` (fails: Missing script)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68be2389a37c83259e45bf94836d764b